### PR TITLE
Feature: Manage multiple guilds simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,20 @@ Here's a list of the currently supported commands:
 ```
 
 ## Installation
-This is a self hosted bot (this might change in the future), just set your bot token in
-the `docker-compose.yml` file and run `docker-compose up -d --build` to deploy it.  
-In order to use Slash commands, the usual `bot` scope in the Discord developer
-portal is not sufficient, you must also grant the `applications.commands` scope.
+### Method 1 - Invite the already hosted bot
+Invite the bot to your server using this [link](https://discord.com/api/oauth2/authorize?client_id=848180282174734378&permissions=8&scope=bot%20applications.commands).
+
+### Method 2 - Host your own copy of the bot
+1. Go to the [Discord Developer Portal](https://discord.com/developers/applications).
+2. Create a new application.
+3. Go to the **Bot** pane and add a bot for your application.
+4. Copy the bot's token and paste it in the `docker-compose.yml` file like indicated.
+5. Go to the **OAuth2** pane, tick `bot` and `applications.commands` under the **Scopes**
+section, tick `Administrator` under the **Bot Permissions** section and copy the
+generated link.
+6. Deploy the bot by running `docker-compose up -d --build`.
+7. Invite your bot to the guild using the link generated in **5**.
+8. Enjoy.
 
 ## Contribution Guidelines
 Please consider reading our [Contribution Guidelines](.github/CONTRIBUTING.md) before

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     build: .
     image: eruditus:latest
     container_name: eruditus
-    restart: always
+    restart: unless-stopped
     environment:
       - DISCORD_TOKEN=<BOT_TOKEN_GOES_HERE>
   mongodb:
     image: mongo:latest
-    container_name: monogdb
-    restart: always
+    container_name: mongodb
+    restart: unless-stopped
     volumes:
       - .data:/data/db

--- a/eruditus/cogs/syscalls/help.py
+++ b/eruditus/cogs/syscalls/help.py
@@ -13,7 +13,7 @@ cog_help = {
         },
         {
             "name": "syscall",
-            "description": "Syscall name or ID (decimal and hex are supported).",
+            "description": "Syscall name or ID (decimal and hex are supported)",
             "option_type": OptionType.STRING,
             "required": True,
         },

--- a/eruditus/config.py
+++ b/eruditus/config.py
@@ -2,7 +2,7 @@
 # CONSTANTS
 ########################################################################################
 MONGODB_URI = "mongodb://mongodb:27017/"
-DBNAME = "eruditus"
+DBNAME_PREFIX = "eruditus"
 CTFTIME_COLLECTION = "ctftime"
 CHALLENGE_COLLECTION = "challenge"
 CTF_COLLECTION = "ctf"
@@ -14,21 +14,13 @@ CTFTIME_URL = "https://ctftime.org"
 USER_AGENT = "Eruditus"
 
 ########################################################################################
-# Required configuration variables
+# Required configuration variables, can be changed later using a command
 ########################################################################################
 # The minimum number of players required to create a CTF automatically
 MINIMUM_PLAYER_COUNT = 5
-# The number of seconds before the CTF starts from which we start considering
-# the votes to decide whether to create the CTF or not (default: 2 hours)
-VOTING_VERDICT_COUNTDOWN = 7200
 # The number of seconds remaining for a CTF to start when we announce it for
 # voting (default: 2 days)
 VOTING_STARTS_COUNTDOWN = 172800
-
-########################################################################################
-# Optional configuration variables, will be decided by the bot if left None
-########################################################################################
-# The category channel where past CTFs results will be moved
-ARCHIVE_CATEGORY_CHANNEL = None
-# The channel ID where we make CTF announcements and enable voting
-ANNOUNCEMENT_CHANNEL = None
+# The number of seconds before the CTF starts from which we start considering
+# the votes to decide whether to create the CTF or not (default: 2 hours)
+VOTING_VERDICT_COUNTDOWN = 7200

--- a/eruditus/tasks/event_manager.py
+++ b/eruditus/tasks/event_manager.py
@@ -14,7 +14,7 @@ from lib.ctftime import scrape_event_info
 
 from config import (
     MONGODB_URI,
-    DBNAME,
+    DBNAME_PREFIX,
     CTFTIME_COLLECTION,
     CONFIG_COLLECTION,
     CTF_COLLECTION,
@@ -24,7 +24,7 @@ from config import (
 )
 
 # MongoDB handle
-mongo = MongoClient(MONGODB_URI)[DBNAME]
+mongo = MongoClient(MONGODB_URI)
 
 
 class EventManager(commands.Cog):
@@ -35,25 +35,11 @@ class EventManager(commands.Cog):
 
     def __init__(self, bot: Bot) -> None:
         self._bot = bot
-        self._config = mongo[CONFIG_COLLECTION].find_one()
-        self._update_events.start()
+        tasks.loop(minutes=30.0, reconnect=True)(self.update_events).start()
         self._announce_upcoming_events.start()
         self._voting_verdict.start()
 
-    async def _get_announcement_channel(self) -> TextChannel:
-        """Attempts to retrieve the announcement channel if it already exists.
-
-        Returns:
-            The announcements channel.
-
-        """
-        if self._config["announcement_channel"]:
-            return await self._bot.fetch_channel(self._config["announcement_channel"])
-
-        return None
-
-    @tasks.loop(minutes=30.0, reconnect=True)
-    async def _update_events(self) -> None:
+    async def update_events(self) -> None:
         """Updates the database with recent events from CTFtime."""
         # Wait until the bot's internal cache is ready
         await self._bot.wait_until_ready()
@@ -72,24 +58,32 @@ class EventManager(commands.Cog):
                 if event_info is None:
                     continue
 
-                # Check if this event was already in the database
-                if mongo[CTFTIME_COLLECTION].find_one({"id": event_info["id"]}):
-                    # In case it was found, we update all its fields, except the
-                    # `announced` boolean.
-                    mongo[CTFTIME_COLLECTION].update_one(
-                        {"id": event_info["id"]}, {"$set": event_info}
-                    )
-                else:
-                    # If this event was new, we add the `announced` and `created`
-                    # booleans, as well as a field to save the announcement message
-                    # id when the event gets announced
-                    event_info["announced"] = False
-                    event_info["created"] = False
-                    event_info["announcement"] = None
-                    mongo[CTFTIME_COLLECTION].insert_one(event_info)
+                for guild in self._bot.guilds:
+                    # Check if this event was already in the database
+                    if mongo[f"{DBNAME_PREFIX}-{guild.id}"][
+                        CTFTIME_COLLECTION
+                    ].find_one({"id": event_info["id"]}):
+                        # In case it was found, we update all its fields, except the
+                        # `announced` boolean.
+                        mongo[f"{DBNAME_PREFIX}-{guild.id}"][
+                            CTFTIME_COLLECTION
+                        ].update_one({"id": event_info["id"]}, {"$set": event_info})
+                    else:
+                        # If this event was new, we add the `announced` and `created`
+                        # booleans, as well as a field to save the announcement message
+                        # id when the event gets announced
+                        event_info["announced"] = False
+                        event_info["created"] = False
+                        event_info["announcement"] = None
+                        mongo[f"{DBNAME_PREFIX}-{guild.id}"][
+                            CTFTIME_COLLECTION
+                        ].insert_one(event_info)
 
         # Prune CTFs that ended
-        mongo[CTFTIME_COLLECTION].delete_many({"end": {"$lt": int(time.time())}})
+        for guild in self._bot.guilds:
+            mongo[f"{DBNAME_PREFIX}-{guild.id}"][CTFTIME_COLLECTION].delete_many(
+                {"end": {"$lt": int(time.time())}}
+            )
 
     @tasks.loop(minutes=30.0, reconnect=True)
     async def _announce_upcoming_events(self) -> None:
@@ -97,86 +91,76 @@ class EventManager(commands.Cog):
         # Wait until the bot's internal cache is ready
         await self._bot.wait_until_ready()
 
-        announcement_channel = await self._get_announcement_channel()
-        # If the channel didn't exist, we create it and save it to the database for
-        # future use
-        if announcement_channel is None:
-            overwrites = {
-                self._bot.guilds[0].default_role: discord.PermissionOverwrite(
-                    send_messages=False, add_reactions=False
-                )
+        for guild in self._bot.guilds:
+            # Get guild config from the database
+            config = mongo[f"{DBNAME_PREFIX}-{guild.id}"][CONFIG_COLLECTION].find_one()
+            announcement_channel = await self._bot.fetch_channel(
+                config["announcement_channel"]
+            )
+
+            # Get non-announced events starting in less than `voting_starts_countdown`
+            # seconds
+            now = int(time.time())
+            query_filter = {
+                "start": {"$lt": now + config["voting_starts_countdown"], "$gt": now},
+                "announced": False,
             }
-            announcement_channel = await self._bot.guilds[0].create_text_channel(
-                name="📢 Event Announcements",
-                overwrites=overwrites,
-            )
-            self._config["announcement_channel"] = announcement_channel.id
-            mongo[CONFIG_COLLECTION].update_one(
-                {"_id": self._config["_id"]},
-                {
-                    "$set": {
-                        "announcement_channel": self._config["announcement_channel"]
-                    }
-                },
-            )
 
-        # Get non-announced events starting in less than `voting_starts_countdown`
-        # seconds
-        now = int(time.time())
-        query_filter = {
-            "start": {"$lt": now + self._config["voting_starts_countdown"], "$gt": now},
-            "announced": False,
-        }
-
-        for event in mongo[CTFTIME_COLLECTION].find(query_filter):
-            # Convert timestamps to dates
-            start_date = datetime.strftime(
-                datetime.fromtimestamp(event["start"]), DATE_FORMAT
-            )
-            end_date = datetime.strftime(
-                datetime.fromtimestamp(event["end"]), DATE_FORMAT
-            )
-
-            embed = (
-                discord.Embed(
-                    title=f"➡️ {event['name']}",
-                    description=(
-                        f"Event website: {event['website']}\n"
-                        f"CTFtime URL: {CTFTIME_URL}/event/{event['id']}"
-                    ),
-                    color=discord.Colour.red(),
+            for event in mongo[f"{DBNAME_PREFIX}-{guild.id}"][CTFTIME_COLLECTION].find(
+                query_filter
+            ):
+                # Convert timestamps to dates
+                start_date = datetime.strftime(
+                    datetime.fromtimestamp(event["start"]), DATE_FORMAT
                 )
-                .set_thumbnail(url=event["logo"])
-                .add_field(name="Description", value=event["description"], inline=False)
-                .add_field(name="Prizes", value=event["prizes"], inline=False)
-                .add_field(
-                    name="Format",
-                    value=f"{event['location']} {event['format']}",
-                    inline=True,
+                end_date = datetime.strftime(
+                    datetime.fromtimestamp(event["end"]), DATE_FORMAT
                 )
-                .add_field(
-                    name="Organizers",
-                    value=", ".join(event["organizers"]),
-                    inline=True,
+
+                embed = (
+                    discord.Embed(
+                        title=f"➡️ {event['name']}",
+                        description=(
+                            f"Event website: {event['website']}\n"
+                            f"CTFtime URL: {CTFTIME_URL}/event/{event['id']}"
+                        ),
+                        color=discord.Colour.red(),
+                    )
+                    .set_thumbnail(url=event["logo"])
+                    .add_field(
+                        name="Description", value=event["description"], inline=False
+                    )
+                    .add_field(name="Prizes", value=event["prizes"], inline=False)
+                    .add_field(
+                        name="Format",
+                        value=f"{event['location']} {event['format']}",
+                        inline=True,
+                    )
+                    .add_field(
+                        name="Organizers",
+                        value=", ".join(event["organizers"]),
+                        inline=True,
+                    )
+                    .add_field(name="Weight", value=event["weight"], inline=True)
+                    .add_field(
+                        name="Timeframe",
+                        value=f"{start_date}\n{end_date}",
+                        inline=False,
+                    )
                 )
-                .add_field(name="Weight", value=event["weight"], inline=True)
-                .add_field(
-                    name="Timeframe",
-                    value=f"{start_date}\n{end_date}",
-                    inline=False,
+
+                message = await announcement_channel.send(embed=embed)
+
+                # Add voting reactions to the message
+                await message.add_reaction("👍")
+                await message.add_reaction("👎")
+
+                event["announced"] = True
+                event["announcement"] = message.id
+
+                mongo[f"{DBNAME_PREFIX}-{guild.id}"][CTFTIME_COLLECTION].update_one(
+                    {"_id": event["_id"]}, {"$set": event}
                 )
-            )
-
-            message = await announcement_channel.send(embed=embed)
-
-            # Add voting reactions to the message
-            await message.add_reaction("👍")
-            await message.add_reaction("👎")
-
-            event["announced"] = True
-            event["announcement"] = message.id
-
-            mongo[CTFTIME_COLLECTION].update_one({"_id": event["_id"]}, {"$set": event})
 
     @tasks.loop(minutes=15.0, reconnect=True)
     async def _voting_verdict(self) -> None:
@@ -186,63 +170,75 @@ class EventManager(commands.Cog):
         # Wait until the bot's internal cache is ready
         await self._bot.wait_until_ready()
 
-        # Get the announcements channel
-        announcement_channel = await self._get_announcement_channel()
-        if announcement_channel is None:
-            return
+        for guild in self._bot.guilds:
+            # Get guild config from the database
+            config = mongo[f"{DBNAME_PREFIX}-{guild.id}"][CONFIG_COLLECTION].find_one()
+            announcement_channel = await self._bot.fetch_channel(
+                config["announcement_channel"]
+            )
 
-        # Get announced events starting in less than `voting_verdict_countdown` seconds
-        now = int(time.time())
-        query_filter = {
-            "start": {
-                "$lt": now + self._config["voting_verdict_countdown"],
-                "$gt": now,
-            },
-            "announced": True,
-            "created": False,
-        }
-        for event in mongo[CTFTIME_COLLECTION].find(query_filter):
-            # Get the announcement message
-            message = await announcement_channel.fetch_message(event["announcement"])
-            vote_yes = discord.utils.get(message.reactions, emoji="👍")
-
-            # If we got enough votes, we create the CTF
-            if vote_yes.count > self._config["minimum_player_count"]:
-                # Get context from our announcement message
-                ctx = await self._bot.get_context(message)
-                # Invoke the CTF cog to create the event
-                await self._bot.get_cog("CTF").createctf.invoke(ctx, name=event["name"])
-
-                # Send a message with the @everyone mention in the announcements channel
-                # with instructions on how to join the CTF
-                await announcement_channel.send(
-                    f"{announcement_channel.guild.default_role}\n"
-                    "A new CTF has been created, you can joing using "
-                    f"`/ctf join \"{event['name']}\"`"
+            # Get announced events starting in less than `voting_verdict_countdown`
+            # seconds
+            now = int(time.time())
+            query_filter = {
+                "start": {
+                    "$lt": now + config["voting_verdict_countdown"],
+                    "$gt": now,
+                },
+                "announced": True,
+                "created": False,
+            }
+            for event in mongo[f"{DBNAME_PREFIX}-{guild.id}"][CTFTIME_COLLECTION].find(
+                query_filter
+            ):
+                # Get the announcement message
+                message = await announcement_channel.fetch_message(
+                    event["announcement"]
                 )
-                # Update the `created` field
-                mongo[CTFTIME_COLLECTION].update_one(
-                    {"_id": event["_id"]}, {"$set": {"created": True}}
-                )
+                vote_yes = discord.utils.get(message.reactions, emoji="👍")
 
-                ctf = mongo[CTF_COLLECTION].find_one({"name": event["name"]})
-                # Start a countdown reminder
-                general_channel = discord.utils.get(
-                    ctx.guild.text_channels,
-                    category_id=ctf["guild_category"],
-                    name="general",
-                )
-                role = discord.utils.get(ctx.guild.roles, id=ctf["guild_role"])
-                timeleft = int(event["start"] - time.time())
+                # If we got enough votes, we create the CTF
+                if vote_yes.count > config["minimum_player_count"]:
+                    # Get context from our announcement message
+                    ctx = await self._bot.get_context(message)
+                    # Invoke the CTF cog to create the event
+                    await self._bot.get_cog("CTF").createctf.invoke(
+                        ctx, name=event["name"]
+                    )
 
-                # Instead of using the @tasks.loop wrapper function around our
-                # `ctf_started_reminder` function, we use this trick to have a different
-                # function object everytime, thus having a different background task and
-                # allowing the function to be run multiple times at the same time.
-                # This is useful if there are more than 1 CTF starting soon
-                tasks.loop(count=1)(self._ctf_started_reminder).start(
-                    timeleft, general_channel, role
-                )
+                    # Send a message with the @everyone mention in the announcements
+                    # channel with instructions on how to join the CTF
+                    await announcement_channel.send(
+                        f"{announcement_channel.guild.default_role}\n"
+                        "A new CTF has been created, you can joing using "
+                        f"`/ctf join \"{event['name']}\"`"
+                    )
+                    # Update the `created` field
+                    mongo[f"{DBNAME_PREFIX}-{guild.id}"][CTFTIME_COLLECTION].update_one(
+                        {"_id": event["_id"]}, {"$set": {"created": True}}
+                    )
+
+                    ctf = mongo[f"{DBNAME_PREFIX}-{guild.id}"][CTF_COLLECTION].find_one(
+                        {"name": event["name"]}
+                    )
+                    # Start a countdown reminder
+                    general_channel = discord.utils.get(
+                        ctx.guild.text_channels,
+                        category_id=ctf["guild_category"],
+                        name="general",
+                    )
+                    role = discord.utils.get(ctx.guild.roles, id=ctf["guild_role"])
+                    timeleft = int(event["start"] - time.time())
+
+                    # Instead of using the @tasks.loop wrapper function around our
+                    # `ctf_started_reminder` function, we use this trick to have a
+                    # different function object everytime, thus having a different
+                    # background task and allowing the function to be run multiple
+                    # times at the same time. This is useful if there are more than
+                    # 1 CTF starting soon
+                    tasks.loop(count=1)(self._ctf_started_reminder).start(
+                        timeleft, general_channel, role
+                    )
 
     async def _ctf_started_reminder(
         self, countdown: int, channel: TextChannel, role: Role
@@ -273,13 +269,17 @@ class EventManager(commands.Cog):
         if payload.member.id == self._bot.user.id:
             return
 
-        announcement_channel = await self._get_announcement_channel()
-        if payload.channel_id == announcement_channel.id:
-            message = await announcement_channel.fetch_message(payload.message_id)
-            for reaction in message.reactions:
-                # Remove all reactions from that user except the one they just added
-                if str(reaction) != str(payload.emoji):
-                    await message.remove_reaction(reaction.emoji, payload.member)
+        # Get the message that got a reaction added
+        message = await self._bot.fetch_message(payload.message_id)
+
+        # If the concerned message doesn't belong to us, do nothing
+        if message.author.id != self._bot.user.id:
+            return
+
+        for reaction in message.reactions:
+            # Remove all reactions from that user except the one they just added
+            if str(reaction) != str(payload.emoji):
+                await message.remove_reaction(reaction.emoji, payload.member)
 
 
 def setup(bot: Bot) -> None:


### PR DESCRIPTION
1. Added the possibility to manage multiple guilds simultaneously, every guild has its own separate database.
2. Updated installation instructions in README.md, there are 2 methods now, either by inviting the bot or self hosting it.
3. Added a new slash command `/config` which enables setting per guild configuration variables easily.