### PR TITLE
Fix several bugs and add new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ make its usage as intuitive as possible.
 Here's a list of the currently supported commands:
 ```
 /help                                                (Show help about the bot usage)
+/request <feature>                                   (Request a new feature from the developer)
+/report <bug>                                        (Send a bug report to the developer)
+/config [<args>]...                                  (Display or alter configuration specific to the guild)
 
 /ctf createctf <ctf_name>                            (Create a new CTF)
 /ctf renamectf <ctf_name>                            (Rename a CTF)

--- a/eruditus/cogs/ctf/ctf.py
+++ b/eruditus/cogs/ctf/ctf.py
@@ -1564,12 +1564,15 @@ class CTF(commands.Cog):
 
         scoreboard = ""
         for rank, team in enumerate(teams, start=1):
-            scoreboard += f"{rank:<10}{team['name']:<50}{round(team['score'], 4)}\n"
+            scoreboard += (
+                f"{['-', '+'][team['name'] == username]} "
+                f"{rank:<10}{team['name']:<50}{round(team['score'], 4)}\n"
+            )
 
         if scoreboard:
             message = (
-                "```ini\n"
-                f"{'[Rank]':<10}{'[Team]':<50}{'[Score]'}\n"
+                "```diff\n"
+                f"  {'Rank':<10}{'Team':<50}{'Score'}\n"
                 f"{scoreboard}"
                 "```"
             )

--- a/eruditus/cogs/ctf/help.py
+++ b/eruditus/cogs/ctf/help.py
@@ -292,5 +292,10 @@ cog_help = {
                 for i in range(1, 5)
             ],
         },
+        "scoreboard": {
+            "name": "scoreboard",
+            "description": "Display scoreboard for the CTF",
+            "options": [],
+        },
     },
 }

--- a/eruditus/cogs/general/general.py
+++ b/eruditus/cogs/general/general.py
@@ -1,4 +1,5 @@
 from importlib import import_module
+from datetime import datetime
 import os
 
 import discord
@@ -19,6 +20,8 @@ from config import (
     MINIMUM_PLAYER_COUNT,
     VOTING_STARTS_COUNTDOWN,
     VOTING_VERDICT_COUNTDOWN,
+    DATE_FORMAT,
+    DEVELOPER_USER_ID,
 )
 
 # MongoDB handle
@@ -134,6 +137,60 @@ class General(commands.Cog):
             },
         )
         await ctx.send("⚙️ Configuration updated")
+
+    @cog_ext.cog_slash(
+        name=cog_help["commands"]["request"]["name"],
+        description=cog_help["commands"]["request"]["description"],
+        options=[
+            create_option(**option)
+            for option in cog_help["commands"]["request"]["options"]
+        ],
+    )
+    async def _request(self, ctx: SlashContext, feature: str) -> None:
+        """Send a feature request to the developer."""
+        developer = await self._bot.fetch_user(DEVELOPER_USER_ID)
+        embed = (
+            discord.Embed(
+                title="💡 **Feature request**",
+                description=feature,
+                colour=discord.Colour.green(),
+            )
+            .set_thumbnail(url=ctx.author.avatar_url)
+            .set_author(name=ctx.author.name)
+            .set_footer(text=datetime.now().strftime(DATE_FORMAT).strip())
+        )
+        await developer.send(embed=embed)
+        await ctx.send(
+            "✅ Your suggestion has been sent to the developer, thanks for your help!",
+            hidden=True,
+        )
+
+    @cog_ext.cog_slash(
+        name=cog_help["commands"]["report"]["name"],
+        description=cog_help["commands"]["report"]["description"],
+        options=[
+            create_option(**option)
+            for option in cog_help["commands"]["report"]["options"]
+        ],
+    )
+    async def _report(self, ctx: SlashContext, bug: str) -> None:
+        """Send a bug report to the developer."""
+        developer = await self._bot.fetch_user(DEVELOPER_USER_ID)
+        embed = (
+            discord.Embed(
+                title="🐛 **Bug report**",
+                description=bug,
+                colour=discord.Colour.green(),
+            )
+            .set_thumbnail(url=ctx.author.avatar_url)
+            .set_author(name=ctx.author.name)
+            .set_footer(text=datetime.now().strftime(DATE_FORMAT).strip())
+        )
+        await developer.send(embed=embed)
+        await ctx.send(
+            "✅ Your bug report has been sent to the developer, thanks for your help!",
+            hidden=True,
+        )
 
 
 def setup(bot: Bot) -> None:

--- a/eruditus/cogs/general/help.py
+++ b/eruditus/cogs/general/help.py
@@ -40,5 +40,29 @@ cog_help = {
                 },
             ],
         },
+        "request": {
+            "name": "request",
+            "description": "Request a new feature from the developer",
+            "options": [
+                {
+                    "name": "feature",
+                    "description": "Description of the new feature you want to suggest",
+                    "option_type": OptionType.STRING,
+                    "required": True,
+                },
+            ],
+        },
+        "report": {
+            "name": "report",
+            "description": "Report a bug to the developer",
+            "options": [
+                {
+                    "name": "bug",
+                    "description": "Description of the bug you encountered",
+                    "option_type": OptionType.STRING,
+                    "required": True,
+                },
+            ],
+        },
     },
 }

--- a/eruditus/config.py
+++ b/eruditus/config.py
@@ -11,6 +11,7 @@ CACHE_DATABASE = "cache"
 SESSION_COLLECTION = "session"
 DATE_FORMAT = "%a, %d %B %Y, %H:%M UTC"
 CTFTIME_URL = "https://ctftime.org"
+DEVELOPER_USER_ID = 305076601253789697
 # CTFtime's nginx server is configured to block requests with specific
 # user agents, like those containing "python-requests"
 USER_AGENT = "Eruditus"

--- a/eruditus/config.py
+++ b/eruditus/config.py
@@ -7,6 +7,8 @@ CTFTIME_COLLECTION = "ctftime"
 CHALLENGE_COLLECTION = "challenge"
 CTF_COLLECTION = "ctf"
 CONFIG_COLLECTION = "config"
+CACHE_DATABASE = "cache"
+SESSION_COLLECTION = "session"
 DATE_FORMAT = "%a, %d %B %Y, %H:%M UTC"
 CTFTIME_URL = "https://ctftime.org"
 # CTFtime's nginx server is configured to block requests with specific

--- a/eruditus/eruditus.py
+++ b/eruditus/eruditus.py
@@ -59,6 +59,10 @@ async def on_guild_remove(guild: Guild) -> None:
 async def on_slash_command_error(ctx: SlashContext, err: Exception) -> None:
     if isinstance(err, commands.errors.CommandNotFound):
         pass
+    elif isinstance(err, discord.errors.NotFound):
+        pass
+    elif isinstance(err, discord.errors.Forbidden):
+        await ctx.send("Forbidden.")
     elif isinstance(err, commands.errors.MissingPermissions):
         await ctx.send("Permission denied.")
     elif isinstance(err, commands.errors.BotMissingPermissions):

--- a/eruditus/lib/ctfd.py
+++ b/eruditus/lib/ctfd.py
@@ -2,6 +2,13 @@ from typing import Tuple, Generator
 import re
 import requests
 from bs4 import BeautifulSoup
+import pymongo
+
+from config import (
+    MONGODB_URI,
+    CACHE_DATABASE,
+    SESSION_COLLECTION,
+)
 
 
 def is_ctfd_platform(ctfd_base_url: str) -> bool:
@@ -17,6 +24,29 @@ def is_ctfd_platform(ctfd_base_url: str) -> bool:
     ctfd_signature = "Powered by CTFd"
     response = requests.get(url=f"{ctfd_base_url.strip()}/")
     return ctfd_signature in response.text
+
+
+def get_cached_cookies(ctfd_base_url, username, password):
+    mongo = pymongo.MongoClient(MONGODB_URI)[CACHE_DATABASE]
+    cached_session = mongo[SESSION_COLLECTION].find_one(
+        {"url": ctfd_base_url.strip(), "username": username, "password": password}
+    )
+    if cached_session is not None:
+        return cached_session["cookies"]
+    return {}
+
+
+def save_cached_session(ctfd_base_url, username, password, cookies):
+    mongo = pymongo.MongoClient(MONGODB_URI)[CACHE_DATABASE]
+    mongo[SESSION_COLLECTION].update_one(
+        {
+            "url": ctfd_base_url.strip(),
+            "username": username,
+            "password": password,
+        },
+        {"$set": {"cookies": cookies}},
+        upsert=True,
+    )
 
 
 def login(ctfd_base_url: str, username: str, password: str) -> dict:
@@ -37,6 +67,14 @@ def login(ctfd_base_url: str, username: str, password: str) -> dict:
     if not is_ctfd_platform(ctfd_base_url):
         return None
 
+    # Check if our cached session cookies (if any) are still valid
+    cookies = get_cached_cookies(ctfd_base_url, username, password)
+    response = requests.head(
+        url=f"{ctfd_base_url}/user", cookies=cookies, allow_redirects=False
+    )
+    if response.status_code == 200:
+        return cookies
+
     # Get the nonce
     response = requests.get(url=f"{ctfd_base_url}/login")
     cookies = response.cookies.get_dict()
@@ -49,7 +87,12 @@ def login(ctfd_base_url: str, username: str, password: str) -> dict:
     response = requests.post(
         url=f"{ctfd_base_url}/login", data=data, cookies=cookies, allow_redirects=False
     )
-    return response.cookies.get_dict()
+    cookies = response.cookies.get_dict()
+
+    # Save session cookies in the database for future use
+    save_cached_session(ctfd_base_url, username, password, cookies)
+
+    return cookies
 
 
 def submit_flag(

--- a/eruditus/lib/ctfd.py
+++ b/eruditus/lib/ctfd.py
@@ -171,7 +171,7 @@ def pull_challenges(
 
     # Confirm that we're dealing with a CTFd platform
     if not is_ctfd_platform(ctfd_base_url):
-        return None
+        return []
 
     # Maybe the challenges endpoint is accessible to the public?
     response = requests.get(
@@ -231,7 +231,7 @@ def get_scoreboard(ctfd_base_url: str, username: str, password: str) -> list:
 
     # Confirm that we're dealing with a CTFd platform
     if not is_ctfd_platform(ctfd_base_url):
-        return None
+        return []
 
     # Maybe the scoreboard endpoint is accessible to the public?
     response = requests.get(
@@ -254,3 +254,4 @@ def get_scoreboard(ctfd_base_url: str, username: str, password: str) -> list:
             {"name": team["name"], "score": team["score"]}
             for team in response.json()["data"][:20]
         ]
+    return []

--- a/eruditus/lib/ctftime.py
+++ b/eruditus/lib/ctftime.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import requests
 from bs4 import BeautifulSoup
 from config import CTFTIME_URL, USER_AGENT
+from lib.util import truncate
 
 
 def scrape_event_info(event_id: int) -> dict:
@@ -61,8 +62,8 @@ def scrape_event_info(event_id: int) -> dict:
     return {
         "id": event_id,
         "name": event_name,
-        "description": event_description,
-        "prizes": event_prizes,
+        "description": truncate(event_description),
+        "prizes": truncate(event_prizes),
         "location": event_location,
         "format": event_format,
         "website": event_website,

--- a/eruditus/lib/util.py
+++ b/eruditus/lib/util.py
@@ -18,6 +18,21 @@ from config import (
 )
 
 
+def truncate(text: str, maxlen=1024) -> str:
+    """Truncates a paragraph to a specific length.
+
+    Args:
+        text: The paragraph to truncate.
+        maxlen: The maximum length of the paragraph.
+
+    Returns:
+        The truncated paragraph
+
+    """
+    etc = "[…]"
+    return f"{text[:maxlen - len(etc)]}{etc}" if len(text) > maxlen - len(etc) else text
+
+
 def sanitize_channel_name(name: str) -> str:
     """Filters out characters that aren't allowed by Discord for guild channels.
 

--- a/eruditus/tasks/event_manager.py
+++ b/eruditus/tasks/event_manager.py
@@ -35,7 +35,10 @@ class EventManager(commands.Cog):
 
     def __init__(self, bot: Bot) -> None:
         self._bot = bot
-        tasks.loop(minutes=30.0, reconnect=True)(self.update_events).start()
+        self._update_events_task = tasks.loop(minutes=30.0, reconnect=True)(
+            self.update_events
+        )
+        self._update_events_task.start()
         self._announce_upcoming_events.start()
         self._voting_verdict.start()
 


### PR DESCRIPTION
### Bug fixes
- `/ctf takenote` wasn't taking attachments into consideration (fixed in 6bd9cba)
- `/ctf status` wasn't displaying all challenges because of Discord's fields limit of 25 per embed (fixed in 6bd9cba)
- After adding a challenge, the command issuer shouldn't be able to see its channel automatically, otherwise it will cause a lot of pain if `/ctf pull` is run, as a lot of challenges will be added (fixed in 6bd9cba)
- Periodic puller wasn't working properly (fixed in 6bd9cba)
- Truncate event information (description and prizes) which can be larger than Discord's allowed field value length of 1024 (fixed in 54a2497)
- `/ctftime upcoming` can be used in DM now (fixed in 23d9b01)
### Optimization
- Session cookies are now cached (fixed in 70ccbbc)
### Features
- Add `/ctf scoreboard` command to display the scoreboard at any time, in addition to posting the scoreboard periodically in its dedicated channel (introduced in 79f276c)
- Add `/request` and `/report` commands to send a feature request or a bug report to the developer (introduced in 22f4755)
- Post solves summary after archiving the CTF (introduced in 718c3a3)
### Enhancements
- Add ability to feed a numerical ID into `/ctf workon` instead of going through the pain of typing a long challenge name (introduced in 7decf6e)
- Format scoreboard to easily spot our team position (introduced in 5e22987)