### PR TITLE
Migrate text channels to private threads

### DIFF
--- a/eruditus/app_commands/ctf/__init__.py
+++ b/eruditus/app_commands/ctf/__init__.py
@@ -257,7 +257,7 @@ class CTF(app_commands.Group):
         # Make threads invitable and lock them if needed.
         locked = permissions == Permissions.RDONLY
         for thread in interaction.guild.threads:
-            if thread.category_id != ctf["guild_category"]:
+            if thread.parent is None or thread.category_id != ctf["guild_category"]:
                 continue
             await thread.edit(locked=locked, invitable=True)
 

--- a/eruditus/app_commands/ctf/__init__.py
+++ b/eruditus/app_commands/ctf/__init__.py
@@ -585,7 +585,7 @@ class CTF(app_commands.Group):
             or discord.utils.get(
                 interaction.guild.text_channels,
                 category=category_channel,
-                name=f"⭐-{channel_name}",
+                name=f"🎯-{channel_name}",
             )
             or await interaction.guild.create_text_channel(
                 name=f"🔄-{channel_name}",
@@ -645,7 +645,7 @@ class CTF(app_commands.Group):
         )
 
         await text_channel.edit(
-            name=text_channel.name.replace("💤", "🔄").replace("⭐", "🔄")
+            name=text_channel.name.replace("💤", "🔄").replace("🎯", "🔄")
         )
 
         await interaction.response.send_message(
@@ -772,7 +772,7 @@ class CTF(app_commands.Group):
         text_channel = challenge_thread.parent
         if len(text_channel.threads) == 0:
             await text_channel.edit(
-                name=text_channel.name.replace("🔄", "💤").replace("⭐", "💤")
+                name=text_channel.name.replace("🔄", "💤").replace("🎯", "💤")
             )
 
     @app_commands.checks.bot_has_permissions(manage_channels=True)
@@ -889,7 +889,7 @@ class CTF(app_commands.Group):
 
         text_channel = interaction.channel.parent
         if text_channel.name.startswith("🔄"):
-            await text_channel.edit(name=text_channel.name.replace("🔄", "⭐"))
+            await text_channel.edit(name=text_channel.name.replace("🔄", "🎯"))
 
     @app_commands.checks.bot_has_permissions(manage_channels=True)
     @app_commands.command()
@@ -967,8 +967,8 @@ class CTF(app_commands.Group):
 
         # In case the CTF category was maxed before adding this new challenge.
         text_channel = interaction.channel.parent
-        if text_channel.name.startswith("⭐"):
-            await text_channel.edit(name=text_channel.name.replace("⭐", "🔄"))
+        if text_channel.name.startswith("🎯"):
+            await text_channel.edit(name=text_channel.name.replace("🎯", "🔄"))
 
         await interaction.followup.send("✅ Challenge unsolved.")
 

--- a/eruditus/app_commands/ctf/__init__.py
+++ b/eruditus/app_commands/ctf/__init__.py
@@ -203,6 +203,13 @@ class CTF(app_commands.Group):
                 await interaction.followup.send("No such CTF.")
                 return
 
+        # In case CTF was already archived.
+        if ctf["archived"]:
+            await interaction.followup.send(
+                "This CTF was already archived.", ephemeral=True
+            )
+            return
+
         category_channel = discord.utils.get(
             interaction.guild.categories, id=ctf["guild_category"]
         )

--- a/eruditus/app_commands/ctf/__init__.py
+++ b/eruditus/app_commands/ctf/__init__.py
@@ -1,6 +1,6 @@
 import re
 from datetime import datetime
-from typing import Callable, List, Optional
+from typing import Callable, Optional
 
 import aiohttp
 import discord
@@ -55,7 +55,7 @@ class CTF(app_commands.Group):
 
     async def _ctf_autocompletion_func(
         self, _: discord.Interaction, current: str
-    ) -> List[Choice[str]]:
+    ) -> list[Choice[str]]:
         """Autocomplete CTF name.
         This function is inefficient, might improve it later.
 
@@ -78,7 +78,7 @@ class CTF(app_commands.Group):
 
     async def _challenge_autocompletion_func(
         self, interaction: discord.Interaction, current: str
-    ) -> List[Choice[str]]:
+    ) -> list[Choice[str]]:
         """Autocomplete challenge name.
         This function is inefficient, might improve it later.
 

--- a/eruditus/app_commands/syscalls/__init__.py
+++ b/eruditus/app_commands/syscalls/__init__.py
@@ -1,6 +1,6 @@
 import os
 from collections import OrderedDict
-from typing import Any, List, Union
+from typing import Any, Union
 
 import discord
 from discord import app_commands
@@ -54,7 +54,7 @@ class Syscalls(app_commands.Command[Any, Any, Any]):
         @self.autocomplete("syscall")
         async def _syscall_autocompletion_func(
             interaction: discord.Interaction, current: str
-        ) -> List[Choice[str]]:
+        ) -> list[Choice[str]]:
             """Autocomplete syscall name.
 
             Args:

--- a/eruditus/app_commands/syscalls/__init__.py
+++ b/eruditus/app_commands/syscalls/__init__.py
@@ -17,7 +17,9 @@ class SyscallTable:
         self.parse_table(architecture)
 
     def parse_table(self, filename: str) -> None:
-        lines = [line.split("\t") for line in open(filename).readlines()]
+        lines = [
+            line.split("\t") for line in open(filename, encoding="utf-8").readlines()
+        ]
 
         for line in lines[1:]:
             syscall = OrderedDict()

--- a/eruditus/config.py
+++ b/eruditus/config.py
@@ -11,7 +11,7 @@ def load_revision() -> str:
     """Get the current revision.
 
     Author:
-        es3n1n (refactoring and handling of multiple cases)
+        @es3n1n (refactoring and handling of multiple cases)
 
     Notes:
         We start by looking up the `.revision` file, if it's present, we use it.
@@ -21,13 +21,13 @@ def load_revision() -> str:
     dot_revision: Path = root_dir / ".revision"
 
     if dot_revision.exists():
-        return open(dot_revision).read()
+        return open(dot_revision, encoding="utf-8").read()
 
     git_dir: Path = root_dir.parent / ".git"
 
     head_ref: Path = git_dir / "refs" / "heads" / "master"
     if head_ref.exists():
-        return open(head_ref).read()
+        return open(head_ref, encoding="utf-8").read()
 
     return "unknown"
 

--- a/eruditus/eruditus.py
+++ b/eruditus/eruditus.py
@@ -619,7 +619,7 @@ class Eruditus(discord.Client):
                             continue
                         attachment = discord.File(raw_image, filename=image.name)
                         img_attachments.append(attachment)
-                    # Otherwise, if it's external, we don't need to fetch it ourself,
+                    # Otherwise, if it's external, we don't need to fetch it ourselves,
                     # we can just send the URL as is.
                     else:
                         img_urls.append(image.url)

--- a/eruditus/eruditus.py
+++ b/eruditus/eruditus.py
@@ -673,11 +673,7 @@ class Eruditus(discord.Client):
                 )
 
                 # Send out challenge information.
-                message = await challenge_thread.send(
-                    content="\n".join(img_urls) if img_urls else None,
-                    embed=embed,
-                    files=img_attachments or None,
-                )
+                message = await challenge_thread.send(embed=embed)
 
                 # Send remaining images if any.
                 if img_urls or img_attachments:

--- a/eruditus/eruditus.py
+++ b/eruditus/eruditus.py
@@ -676,11 +676,10 @@ class Eruditus(discord.Client):
                 message = await challenge_thread.send(embed=embed)
 
                 # Send remaining images if any.
-                if img_urls or img_attachments:
-                    await challenge_thread.send(
-                        content="\n".join(img_urls) if img_urls else None,
-                        files=img_attachments or None,
-                    )
+                for img_url in img_urls:
+                    await challenge_thread.send(content=img_url)
+                if img_attachments:
+                    await challenge_thread.send(files=img_attachments)
 
                 # Pin the challenge info message.
                 await message.pin()

--- a/eruditus/eruditus.py
+++ b/eruditus/eruditus.py
@@ -5,7 +5,7 @@ import re
 import traceback
 from binascii import hexlify
 from datetime import datetime, timedelta
-from typing import List, Union
+from typing import Any, Union
 
 import aiohttp
 import discord
@@ -58,21 +58,27 @@ class Eruditus(discord.Client):
         self.tree = discord.app_commands.CommandTree(self)
         self.challenge_puller_is_running = False
 
-    async def create_ctf(self, name: str, live: bool = True) -> Union[dict, None]:
+    async def create_ctf(
+        self, name: str, live: bool = True, return_if_exists: bool = False
+    ) -> Union[dict, None]:
         """Create a CTF along with its channels and role.
 
         Args:
             name: CTF name.
             live: True if the CTF is ongoing.
+            return_if_exists: Causes the function to return the CTF object instead of
+                None in case it exists.
 
         Returns:
             A dictionary containing information about the created CTF, or None if the
             CTF already exists.
         """
         # Check if the CTF already exists (case insensitive).
-        if MONGO[DBNAME][CTF_COLLECTION].find_one(
+        if ctf := MONGO[DBNAME][CTF_COLLECTION].find_one(
             {"name": re.compile(f"^{re.escape(name.strip())}$", re.IGNORECASE)}
         ):
+            if return_if_exists:
+                return ctf
             return None
 
         # The bot is supposed to be part of a single guild.
@@ -177,7 +183,7 @@ class Eruditus(discord.Client):
 
     async def on_ready(self) -> None:
         for guild in self.guilds:
-            logger.info(f"{self.user} connected to {guild}")
+            logger.info("%s connected to %s", self.user, guild)
 
         # Sync global and guild specific commands.
         await self.tree.sync()
@@ -186,10 +192,64 @@ class Eruditus(discord.Client):
         await self.change_presence(activity=discord.Game(name="/help"))
 
     async def on_guild_join(self, guild: discord.Guild) -> None:
-        logger.info(f"{self.user} joined {guild}!")
+        logger.info("%s joined %s!", self.user, guild)
 
     async def on_guild_remove(self, guild: discord.Guild) -> None:
-        logger.info(f"{self.user} left {guild}.")
+        logger.info("%s left %s.", self.user, guild)
+
+    async def _do_ctf_registration(
+        self,
+        ctf: dict[str, Any],
+        guild: discord.Guild,
+        event: discord.ScheduledEvent,
+        users: list[discord.User],
+    ) -> None:
+        # Register a team account if it's a supported platform.
+        url = event.location.split(" — ")[1]
+        password = hexlify(os.urandom(32)).decode()
+
+        # Match the platform
+        ctx = PlatformCTX(
+            base_url=url,
+            args={"username": TEAM_NAME, "password": password, "email": TEAM_EMAIL},
+        )
+        platform = await match_platform(ctx)
+        if platform is None:
+            # Unsupported platform
+            return
+
+        result = await platform.register(ctx)
+
+        if result.success:
+            # Add credentials.
+            ctf["credentials"]["url"] = url
+            ctf["credentials"]["username"] = TEAM_NAME
+            ctf["credentials"]["password"] = password
+            ctf["credentials"]["token"] = result.token
+            ctf["credentials"]["teamToken"] = result.invite
+
+            MONGO[DBNAME][CTF_COLLECTION].update_one(
+                {"_id": ctf["_id"]},
+                {"$set": {"credentials": ctf["credentials"]}},
+            )
+
+            creds_channel = discord.utils.get(
+                guild.text_channels, id=ctf["guild_channels"]["credentials"]
+            )
+            message = (
+                f"CTF platform: {url}\n"
+                "```yaml\n"
+                f"Username: {TEAM_NAME}\n"
+                f"Password: {password}\n"
+            )
+
+            if result.invite is not None:
+                message += f"Invite: {result.invite}\n"
+
+            message += "```"
+
+            await creds_channel.purge()
+            await creds_channel.send(message)
 
     async def on_scheduled_event_update(
         self, before: discord.ScheduledEvent, after: discord.ScheduledEvent
@@ -208,68 +268,18 @@ class Eruditus(discord.Client):
             users = [user async for user in after.users()]
             if len(users) < MIN_PLAYERS:
                 return
-            ctf = await self.create_ctf(event_name, live=True)
-            if ctf is None:
-                ctf = MONGO[DBNAME][CTF_COLLECTION].find_one(
-                    {
-                        "name": re.compile(
-                            f"^{re.escape(event_name.strip())}$", re.IGNORECASE
-                        )
-                    }
-                )
-
-            # Register a team account if it's a supported platform.
-            url = after.location.split(" — ")[1]
-            password = hexlify(os.urandom(32)).decode()
-
-            # Matching platform
-            ctx = PlatformCTX(
-                base_url=url,
-                args=dict(username=TEAM_NAME, password=password, email=TEAM_EMAIL),
-            )
-            platform = await match_platform(ctx)
-            if platform is None:
-                # unsupported platform gg
-                return
-
-            result = await platform.register(ctx)
-
-            if result.success:
-                # Add credentials.
-                ctf["credentials"]["url"] = url
-                ctf["credentials"]["username"] = TEAM_NAME
-                ctf["credentials"]["password"] = password
-                ctf["credentials"]["token"] = result.token
-                ctf["credentials"]["teamToken"] = result.invite
-
-                MONGO[DBNAME][CTF_COLLECTION].update_one(
-                    {"_id": ctf["_id"]},
-                    {"$set": {"credentials": ctf["credentials"]}},
-                )
-
-                creds_channel = discord.utils.get(
-                    guild.text_channels, id=ctf["guild_channels"]["credentials"]
-                )
-                message = (
-                    f"CTF platform: {url}\n"
-                    "```yaml\n"
-                    f"Username: {TEAM_NAME}\n"
-                    f"Password: {password}\n"
-                )
-
-                if result.invite is not None:
-                    message += f"Invite: {result.invite}\n"
-
-                message += "```"
-
-                await creds_channel.purge()
-                await creds_channel.send(message)
+            ctf = await self.create_ctf(after.name, live=True, return_if_exists=True)
 
             # Give the CTF role to the interested people if they didn't get it yet.
             role = discord.utils.get(guild.roles, id=ctf["guild_role"])
             for user in users:
                 member = await guild.fetch_member(user.id)
                 await member.add_roles(role)
+
+            # Register to the CTF.
+            await self._do_ctf_registration(
+                ctf=ctf, guild=guild, event=after, users=users
+            )
 
             # Substitute the ⏰ in the category channel name with a 🔴 to say that
             # we're live.
@@ -389,69 +399,18 @@ class Eruditus(discord.Client):
                 continue
 
             # If a CTF is starting soon, we create it if it wasn't created yet.
-            ctf = await self.create_ctf(event_name, live=False)
-            if ctf is None:
-                ctf = MONGO[DBNAME][CTF_COLLECTION].find_one(
-                    {
-                        "name": re.compile(
-                            f"^{re.escape(event_name.strip())}$",
-                            re.IGNORECASE,
-                        )
-                    }
-                )
+            ctf = await self.create_ctf(event_name, live=False, return_if_exists=True)
 
-            # Register a team account if the platform is supported.
-            url = scheduled_event.location.split(" — ")[1]
-            password = hexlify(os.urandom(32)).decode()
-
-            # Matching platform
-            ctx = PlatformCTX(
-                base_url=url,
-                args=dict(username=TEAM_NAME, password=password, email=TEAM_EMAIL),
-            )
-            platform = await match_platform(ctx)
-            if platform is None:
-                # unsupported platform gg
-                return
-
-            result = await platform.register(ctx)
-
-            if result.success:
-                # Add credentials.
-                ctf["credentials"]["url"] = url
-                ctf["credentials"]["username"] = TEAM_NAME
-                ctf["credentials"]["password"] = password
-                ctf["credentials"]["token"] = result.token
-                ctf["credentials"]["teamToken"] = result.invite
-
-                MONGO[DBNAME][CTF_COLLECTION].update_one(
-                    {"_id": ctf["_id"]},
-                    {"$set": {"credentials": ctf["credentials"]}},
-                )
-
-                creds_channel = discord.utils.get(
-                    guild.text_channels, id=ctf["guild_channels"]["credentials"]
-                )
-                message = (
-                    f"CTF platform: {url}\n"
-                    "```yaml\n"
-                    f"Username: {TEAM_NAME}\n"
-                    f"Password: {password}\n"
-                )
-
-                if result.invite is not None:
-                    message += f"Invite: {result.invite}\n"
-
-                message += "```"
-
-                await creds_channel.purge()
-                await creds_channel.send(message)
-
-            # Add interested people automatically.
+            # Give the CTF role to the interested people if they didn't get it yet.
             role = discord.utils.get(guild.roles, id=ctf["guild_role"])
             for user in users:
                 member = await guild.fetch_member(user.id)
                 await member.add_roles(role)
+
+            # Register to the CTF.
+            await self._do_ctf_registration(
+                ctf=ctf, guild=guild, event=scheduled_event, users=users
+            )
 
             # Send a reminder that the CTF is starting soon.
             if reminder_channel:
@@ -635,7 +594,7 @@ class Eruditus(discord.Client):
                     or discord.utils.get(
                         guild.text_channels,
                         category=category_channel,
-                        name=f"⭐-{channel_name}",
+                        name=f"🎯-{channel_name}",
                     )
                     or await guild.create_text_channel(
                         name=f"🔄-{channel_name}",
@@ -664,7 +623,7 @@ class Eruditus(discord.Client):
                 )
                 tags = ", ".join(challenge.tags or []) or "No tags."
 
-                files: List[str] = list()
+                files: list[str] = list()
                 for file in challenge.files:
                     if file.name is not None:
                         hyperlink = f"[{file.name}]({file.url})"
@@ -742,7 +701,7 @@ class Eruditus(discord.Client):
                 )
 
                 await text_channel.edit(
-                    name=text_channel.name.replace("💤", "🔄").replace("⭐", "🔄")
+                    name=text_channel.name.replace("💤", "🔄").replace("🎯", "🔄")
                 )
 
         self.challenge_puller_is_running = False
@@ -760,11 +719,15 @@ class Eruditus(discord.Client):
             if ctf["credentials"]["url"] is None:
                 continue
 
-            # Matching platform
+            # Match the platform
             ctx = PlatformCTX.from_credentials(ctf["credentials"])
-            platform = await match_platform(ctx)
+            try:
+                platform = await match_platform(ctx)
+            except aiohttp.ClientError:
+                continue
+
             if platform is None:
-                # unsupported platform gg
+                # Unsupported platform
                 return
 
             try:

--- a/eruditus/lib/platforms/abc.py
+++ b/eruditus/lib/platforms/abc.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from enum import IntEnum, auto, unique
 from typing import AsyncIterator, Awaitable, Callable, Optional
 
+import aiohttp
 from pydantic import field_validator
 
 
@@ -386,6 +387,13 @@ class PlatformABC(ABC):
     @classmethod
     @abstractmethod
     async def login(cls, ctx: PlatformCTX) -> Optional[Session]:
+        pass
+
+    @classmethod
+    @abstractmethod
+    async def fetch(
+        cls, ctx: PlatformCTX, path: str
+    ) -> Optional[aiohttp.ClientResponse]:
         pass
 
     @classmethod

--- a/eruditus/lib/platforms/abc.py
+++ b/eruditus/lib/platforms/abc.py
@@ -101,6 +101,7 @@ class Challenge:
     description: Optional[str] = None
     value: Optional[int] = None
     files: Optional[list[ChallengeFile]] = None
+    images: Optional[list[ChallengeFile]] = None
     connection_info: Optional[str] = None
     solves: Optional[int] = None
     solved_by: Optional[list[ChallengeSolver]] = None

--- a/eruditus/lib/platforms/abc.py
+++ b/eruditus/lib/platforms/abc.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import IntEnum, auto, unique
-from typing import AsyncIterator, Awaitable, Callable, Dict, List, Optional
+from typing import AsyncIterator, Awaitable, Callable, Optional
 
 from pydantic import field_validator
 
@@ -23,7 +23,7 @@ class Session:
     """
 
     token: Optional[str] = None
-    cookies: Dict[str, str] = field(default_factory=dict)
+    cookies: dict[str, str] = field(default_factory=dict)
 
     def validate(self) -> bool:
         return len(self.cookies) > 0 or self.token is not None
@@ -95,21 +95,21 @@ class Challenge:
     """
 
     id: str
-    tags: Optional[List[str]] = None
+    tags: Optional[list[str]] = None
     category: Optional[str] = None
     name: Optional[str] = None
     description: Optional[str] = None
     value: Optional[int] = None
-    files: Optional[List[ChallengeFile]] = None
+    files: Optional[list[ChallengeFile]] = None
     connection_info: Optional[str] = None
     solves: Optional[int] = None
-    solved_by: Optional[List[ChallengeSolver]] = None
+    solved_by: Optional[list[ChallengeSolver]] = None
 
     @classmethod
     @field_validator("solved_by", mode="before")
     def validate_solved_by(
-        cls, value: Optional[List[ChallengeSolver]]
-    ) -> Optional[List[ChallengeSolver]]:
+        cls, value: Optional[list[ChallengeSolver]]
+    ) -> Optional[list[ChallengeSolver]]:
         if value is None:
             return value
 
@@ -241,7 +241,7 @@ class Team:
     name: str
     score: Optional[int] = None
     invite_token: Optional[str] = None
-    solves: Optional[List[Challenge]] = None
+    solves: Optional[list[Challenge]] = None
 
     def __eq__(self, other: Optional["Team"]) -> bool:
         if other is None:
@@ -300,7 +300,7 @@ class PlatformCTX:
     """
 
     base_url: str
-    args: Dict[str, str] = field(default_factory=dict)
+    args: dict[str, str] = field(default_factory=dict)
     session: Optional[Session] = None
 
     @property
@@ -308,7 +308,7 @@ class PlatformCTX:
         return self.base_url.strip("/")
 
     @staticmethod
-    def from_credentials(credentials: Dict[str, str]) -> "PlatformCTX":
+    def from_credentials(credentials: dict[str, str]) -> "PlatformCTX":
         """Custom constructor that initializes a class instance from a set of
         credentials.
 
@@ -321,7 +321,7 @@ class PlatformCTX:
             args=credentials,
         )
 
-    def get_args(self, *required_fields: str, **kwargs: str) -> Dict[str, str]:
+    def get_args(self, *required_fields: str, **kwargs: str) -> dict[str, str]:
         """Get arguments from the set of custom arguments (i.e., self.args), optionally
         extending them with additional items.
 
@@ -332,7 +332,7 @@ class PlatformCTX:
         Returns:
             A dictionary of arguments (e.g., email, password, etc.).
         """
-        result: Dict[str, str] = {
+        result: dict[str, str] = {
             key: value for key, value in self.args.items() if key in required_fields
         }
 

--- a/eruditus/lib/platforms/abc.py
+++ b/eruditus/lib/platforms/abc.py
@@ -1,10 +1,10 @@
+import io
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import IntEnum, auto, unique
 from typing import AsyncIterator, Awaitable, Callable, Optional
 
-import aiohttp
 from pydantic import field_validator
 
 
@@ -391,9 +391,7 @@ class PlatformABC(ABC):
 
     @classmethod
     @abstractmethod
-    async def fetch(
-        cls, ctx: PlatformCTX, path: str
-    ) -> Optional[aiohttp.ClientResponse]:
+    async def fetch(cls, ctx: PlatformCTX, url: str) -> Optional[io.BytesIO]:
         pass
 
     @classmethod

--- a/eruditus/lib/platforms/ctfd.py
+++ b/eruditus/lib/platforms/ctfd.py
@@ -1,6 +1,6 @@
 import re
 from logging import getLogger
-from typing import AsyncIterator, Dict
+from typing import AsyncIterator
 
 import aiohttp
 from bs4 import BeautifulSoup
@@ -152,7 +152,7 @@ class CTFd(PlatformABC):
             tries_left = int(matched.group("tries")) if matched is not None else None
 
             # Parse the flag state.
-            rules: Dict[str, SubmittedFlagState] = {
+            rules: dict[str, SubmittedFlagState] = {
                 "paused": SubmittedFlagState.CTF_PAUSED,
                 "ratelimited": SubmittedFlagState.RATE_LIMITED,
                 "incorrect": SubmittedFlagState.INCORRECT,

--- a/eruditus/lib/platforms/ctfd.py
+++ b/eruditus/lib/platforms/ctfd.py
@@ -97,6 +97,26 @@ class CTFd(PlatformABC):
             ctx.session = Session(cookies=cookies)
             return ctx.session
 
+    async def fetch(
+        cls, ctx: PlatformCTX, path: str
+    ) -> Optional[aiohttp.ClientResponse]:
+        """Fetch a URL endpoint from the CTFd platform and return its response.
+
+        Args:
+            path: The URL path (e.g., /a/b/c).
+
+        Returns:
+            The HTTP response object.
+        """
+        if not await ctx.login(cls.login):
+            return
+
+        url = f"{ctx.url_stripped}/{path.lstrip('/')}"
+        async with aiohttp.request(
+            method="get", url=url, cookies=ctx.session.cookies
+        ) as response:
+            return response
+
     @classmethod
     async def submit_flag(
         cls, ctx: PlatformCTX, challenge_id: str, flag: str
@@ -203,8 +223,8 @@ class CTFd(PlatformABC):
             )
             if msg_response:
                 logger.warning(
-                    "Suppressing challenge getter warnings because "
-                    f'of the "{msg_response.message}"'
+                    'Suppressing challenge getter warnings because of the "%s"',
+                    msg_response.message,
                 )
 
             # Validating and deserializing response

--- a/eruditus/lib/platforms/rctf.py
+++ b/eruditus/lib/platforms/rctf.py
@@ -173,7 +173,7 @@ class RCTF(PlatformABC):
 
             # Iterate over challenges and parse them
             for challenge in data.data:
-                yield challenge.convert()
+                yield challenge.convert(ctx.url_stripped)
 
     @classmethod
     async def pull_scoreboard(

--- a/eruditus/lib/platforms/rctf.py
+++ b/eruditus/lib/platforms/rctf.py
@@ -1,4 +1,4 @@
-from typing import AsyncIterator, Dict
+from typing import AsyncIterator
 
 import aiohttp
 
@@ -25,7 +25,7 @@ from lib.validators.rctf import (
 )
 
 
-def generate_headers(ctx: PlatformCTX) -> Dict[str, str]:
+def generate_headers(ctx: PlatformCTX) -> dict[str, str]:
     if not ctx.session or not ctx.session.validate():
         return {}
 
@@ -98,7 +98,7 @@ class RCTF(PlatformABC):
             result: SubmittedFlag = SubmittedFlag(state=SubmittedFlagState.UNKNOWN)
 
             # Lookup table for flag submission states
-            statuses: Dict[str, SubmittedFlagState] = {
+            statuses: dict[str, SubmittedFlagState] = {
                 "goodFlag": SubmittedFlagState.CORRECT,
                 "badNotStarted": SubmittedFlagState.CTF_NOT_STARTED,
                 "badEnded": SubmittedFlagState.CTF_ENDED,

--- a/eruditus/lib/platforms/rctf.py
+++ b/eruditus/lib/platforms/rctf.py
@@ -74,6 +74,26 @@ class RCTF(PlatformABC):
             ctx.args["authToken"] = data.data.authToken
             return Session(token=data.data.authToken)
 
+    async def fetch(
+        cls, ctx: PlatformCTX, path: str
+    ) -> Optional[aiohttp.ClientResponse]:
+        """Fetch a URL endpoint from the rCTF platform and return its response.
+
+        Args:
+            path: The URL path (e.g., /a/b/c).
+
+        Returns:
+            The HTTP response object.
+        """
+        if not await ctx.login(cls.login):
+            return
+
+        url = f"{ctx.url_stripped}/{path.lstrip('/')}"
+        async with aiohttp.request(
+            method="get", url=url, headers=generate_headers(ctx)
+        ) as response:
+            return response
+
     @classmethod
     async def submit_flag(
         cls, ctx: PlatformCTX, challenge_id: str, flag: str

--- a/eruditus/lib/platforms/rctf.py
+++ b/eruditus/lib/platforms/rctf.py
@@ -189,6 +189,7 @@ class RCTF(PlatformABC):
     @classmethod
     async def register(cls, ctx: PlatformCTX) -> RegistrationStatus:
         # Assert registration data
+        ctx.args["team"] = ctx.args.get("team") or ctx.args.get("username")
         if any(is_empty_string(ctx.args.get(value)) for value in ("team", "email")):
             return RegistrationStatus(
                 success=False, message="Not enough values in context"

--- a/eruditus/lib/types.py
+++ b/eruditus/lib/types.py
@@ -13,11 +13,6 @@ class EncodingOperationMode(Enum):
     decode = 2
 
 
-class ArchiveMode(Enum):
-    minimal = 1
-    all = 2
-
-
 class CTFStatusMode(Enum):
     active = 1
     all = 2

--- a/eruditus/lib/util.py
+++ b/eruditus/lib/util.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from hashlib import md5
 from logging import Logger
 from string import ascii_lowercase, digits
-from typing import Any, Dict, List, Optional, Type, TypeVar
+from typing import Any, Optional, Type, TypeVar
 
 from aiohttp import ClientResponse
 from pydantic import TypeAdapter, ValidationError
@@ -156,7 +156,7 @@ async def deserialize_response(
     Returns:
         A deserialized response if the response is valid, None otherwise.
     """
-    response_ranges: List[List[int]] = [
+    response_ranges: list[list[int]] = [
         [200, 299],  # ok
         [400, 499],  # client-side errors
     ]
@@ -168,7 +168,7 @@ async def deserialize_response(
     if not valid_status_code:
         return None
 
-    response_json: Dict[str, Any] = await response.json()
+    response_json: dict[str, Any] = await response.json()
 
     try:
         return TypeAdapter(model).validate_python(response_json)

--- a/eruditus/lib/validators/ctfd.py
+++ b/eruditus/lib/validators/ctfd.py
@@ -83,7 +83,7 @@ class CTFDChallenge(BaseModel):
             return None
 
         # Convert to markdown.
-        md = html2md(self.description)
+        md = html2md(self.description, heading_style="atx")
         # Remove all images.
         md = re.sub(r'[^\S\r\n]*!\[[^\]]*\]\((.*?)\s*("(?:.*[^"])")?\s*\)\s*', "", md)
         # Remove multilines.

--- a/eruditus/lib/validators/ctfd.py
+++ b/eruditus/lib/validators/ctfd.py
@@ -46,7 +46,7 @@ class CTFDChallenge(BaseModel):
     class Hint(BaseModel):
         id: int
         cost: int
-        content: str
+        content: Optional[str] = None
 
     # Required fields
     id: int

--- a/eruditus/lib/validators/ctfd.py
+++ b/eruditus/lib/validators/ctfd.py
@@ -77,7 +77,6 @@ class CTFDChallenge(BaseModel):
     files: Optional[list[str]] = None
     hints: Optional[list[Hint]] = None
     view: Optional[str] = None
-    images: Optional[list[str]] = None
 
     def _description_to_markdown(self) -> None:
         if self.description is None:

--- a/eruditus/lib/validators/rctf.py
+++ b/eruditus/lib/validators/rctf.py
@@ -1,9 +1,13 @@
+import re
 from datetime import datetime
 from typing import Optional
 
+from bs4 import BeautifulSoup
+from markdownify import markdownify as html2md
 from pydantic import BaseModel, field_validator
 
 from lib.platforms.abc import Challenge, ChallengeFile, ChallengeSolver, Team
+from lib.util import extract_filename_from_url
 
 
 class BaseRCTFResponse(BaseModel):
@@ -47,14 +51,38 @@ class RCTFChallenge(BaseModel):
     description: Optional[str] = None
     author: Optional[str] = None
 
-    def convert(self) -> Challenge:
+    def _description_to_markdown(self) -> None:
+        if self.description is None:
+            return None
+
+        # Convert to markdown.
+        md = html2md(self.description)
+        # Remove all images.
+        md = re.sub(r'[^\S\r\n]*!\[[^\]]*\]\((.*?)\s*("(?:.*[^"])")?\s*\)\s*', "", md)
+        # Remove multilines.
+        md = re.sub(r"\n+", "\n", md)
+        return md
+
+    def convert(self, url_stripped: str) -> Challenge:
         return Challenge(
             id=self.id,
             category=self.category,
             name=self.name,
-            description=self.description,
+            description=self._description_to_markdown(),
             value=self.points if self.points is not None else 0,
             files=[x.convert() for x in self.files] if self.files is not None else None,
+            images=[
+                ChallengeFile(
+                    url=f"{url_stripped}/{img['src'].lstrip('/')}"
+                    if img["src"].startswith("/")
+                    else img["src"],
+                    name=extract_filename_from_url(img["src"]),
+                )
+                for img in BeautifulSoup(self.description, "html.parser").findAll("img")
+                if img.get("src")
+            ]
+            if self.description is not None
+            else None,
             solves=self.solves if self.solves is not None else 0,
         )
 

--- a/eruditus/lib/validators/rctf.py
+++ b/eruditus/lib/validators/rctf.py
@@ -56,7 +56,7 @@ class RCTFChallenge(BaseModel):
             return None
 
         # Convert to markdown.
-        md = html2md(self.description)
+        md = html2md(self.description, heading_style="atx")
         # Remove all images.
         md = re.sub(r'[^\S\r\n]*!\[[^\]]*\]\((.*?)\s*("(?:.*[^"])")?\s*\)\s*', "", md)
         # Remove multilines.

--- a/eruditus/lib/validators/rctf.py
+++ b/eruditus/lib/validators/rctf.py
@@ -35,7 +35,7 @@ class RCTFChallenge(BaseModel):
     solves: Optional[int]
     id: str
 
-    # Optional vales that would be set only in `/challs` response
+    # Optional values that would be set only in `/challs` response
     class File(BaseModel):
         url: str
         name: str

--- a/eruditus/msg_components/buttons/workon.py
+++ b/eruditus/msg_components/buttons/workon.py
@@ -27,11 +27,11 @@ class WorkonButton(discord.ui.View):
 
         challenge["players"].append(interaction.user.name)
 
-        challenge_channel = discord.utils.get(
-            interaction.guild.text_channels, id=challenge["channel"]
+        challenge_thread = discord.utils.get(
+            interaction.guild.threads, id=challenge["thread"]
         )
 
-        await challenge_channel.set_permissions(interaction.user, read_messages=True)
+        await challenge_thread.add_user(interaction.user)
 
         MONGO[DBNAME][CHALLENGE_COLLECTION].update_one(
             {"_id": challenge["_id"]},
@@ -43,7 +43,7 @@ class WorkonButton(discord.ui.View):
             view=UnworkonButton(name=self.name),
             ephemeral=True,
         )
-        await challenge_channel.send(
+        await challenge_thread.send(
             f"{interaction.user.mention} wants to collaborate 🤝"
         )
 
@@ -76,8 +76,8 @@ class UnworkonButton(discord.ui.View):
 
         challenge["players"].remove(interaction.user.name)
 
-        challenge_channel = discord.utils.get(
-            interaction.guild.text_channels, id=challenge["channel"]
+        challenge_thread = discord.utils.get(
+            interaction.guild.threads, id=challenge["thread"]
         )
 
         MONGO[DBNAME][CHALLENGE_COLLECTION].update_one(
@@ -88,8 +88,8 @@ class UnworkonButton(discord.ui.View):
         await interaction.response.edit_message(
             content=f"✅ Removed from the `{challenge['name']}` challenge.", view=None
         )
-        await challenge_channel.send(
+        await challenge_thread.send(
             f"{interaction.user.mention} left you alone, what a chicken! 🐥"
         )
 
-        await challenge_channel.set_permissions(interaction.user, overwrite=None)
+        await challenge_thread.remove_user(interaction.user)

--- a/eruditus/msg_components/forms/flag.py
+++ b/eruditus/msg_components/forms/flag.py
@@ -69,8 +69,6 @@ class FlagSubmissionForm(discord.ui.Modal, title="Flag submission form"):
             await interaction.followup.send(error_msg)
             return
 
-        # @note: @es3n1n: Ignore other states, they should be handled within the
-        # `error_messages` dict
         if result.state != SubmittedFlagState.CORRECT:
             return
 
@@ -179,4 +177,4 @@ class FlagSubmissionForm(discord.ui.Modal, title="Flag submission form"):
 
         text_channel = interaction.channel.parent
         if text_channel.name.startswith("🔄"):
-            await text_channel.edit(name=text_channel.name.replace("🔄", "⭐"))
+            await text_channel.edit(name=text_channel.name.replace("🔄", "🎯"))

--- a/eruditus/msg_components/forms/flag.py
+++ b/eruditus/msg_components/forms/flag.py
@@ -1,6 +1,5 @@
 import re
 from datetime import datetime
-from typing import Dict
 
 import discord
 from discord import HTTPException
@@ -51,7 +50,7 @@ class FlagSubmissionForm(discord.ui.Modal, title="Flag submission form"):
             await interaction.followup.send("❌ Failed to submit the flag.")
             return
 
-        error_messages: Dict[SubmittedFlagState, str] = {
+        error_messages: dict[SubmittedFlagState, str] = {
             SubmittedFlagState.ALREADY_SUBMITTED: "You already solved this challenge.",
             SubmittedFlagState.INCORRECT: "❌ Incorrect flag.",
             SubmittedFlagState.CTF_NOT_STARTED: "❌ CTF not started.",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 discord==2.2.0
 pydantic==2.3
+markdownify==0.11.6
 beautifulsoup4
 python-dotenv
 pymongo


### PR DESCRIPTION
This PR addresses issue #16 
By moving to private threads, not only we make things more organized, but we also bypass the 50 channels limit, since we can have up to 1000 active threads in the guild.

There's also some refactoring.